### PR TITLE
Use the correct tag prefix for featomic dependency

### DIFF
--- a/featomic-torch/CMakeLists.txt
+++ b/featomic-torch/CMakeLists.txt
@@ -21,7 +21,7 @@ file(READ ${CMAKE_CURRENT_SOURCE_DIR}/VERSION FEATOMIC_TORCH_VERSION)
 string(STRIP ${FEATOMIC_TORCH_VERSION} FEATOMIC_TORCH_VERSION)
 
 include(cmake/dev-versions.cmake)
-create_development_version("${FEATOMIC_TORCH_VERSION}" FEATOMIC_TORCH_FULL_VERSION)
+create_development_version("${FEATOMIC_TORCH_VERSION}" FEATOMIC_TORCH_FULL_VERSION "featomic-torch-v")
 message(STATUS "Building featomic-torch v${FEATOMIC_TORCH_FULL_VERSION}")
 
 # strip any -dev/-rc suffix on the version since project(VERSION) does not support it
@@ -85,7 +85,7 @@ if (NOT "$ENV{FEATOMIC_NO_LOCAL_DEPS}" STREQUAL "1")
     # If building a dev version, we also need to update the
     # REQUIRED_FEATOMIC_VERSION in the same way we update the
     # featomic-torch version
-    create_development_version("${REQUIRED_FEATOMIC_VERSION}" FEATOMIC_FULL_VERSION)
+    create_development_version("${REQUIRED_FEATOMIC_VERSION}" FEATOMIC_FULL_VERSION "featomic-v")
 else()
     set(FEATOMIC_FULL_VERSION ${REQUIRED_FEATOMIC_VERSION})
 endif()

--- a/featomic-torch/cmake/dev-versions.cmake
+++ b/featomic-torch/cmake/dev-versions.cmake
@@ -23,7 +23,7 @@ endif()
 
 # Get the time of the last modification since the last tag/release, and a hash
 # of the latest commit/full state of a dirty repository
-function(git_version_info _output_n_commits_ _output_git_hash_)
+function(git_version_info _tag_prefix_ _output_n_commits_ _output_git_hash_)
     set(_script_ "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/../../scripts/git-version-info.py")
 
     if (EXISTS "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/git_version_info")
@@ -37,7 +37,7 @@ function(git_version_info _output_n_commits_ _output_git_hash_)
         # When building from a checkout, we'll need to run the script
         find_package(Python COMPONENTS Interpreter REQUIRED)
         execute_process(
-            COMMAND "${Python_EXECUTABLE}" "${_script_}" "featomic-torch-v"
+            COMMAND "${Python_EXECUTABLE}" "${_script_}" "${_tag_prefix_}"
             RESULT_VARIABLE _status_
             OUTPUT_VARIABLE _stdout_
             ERROR_VARIABLE _stderr_
@@ -72,8 +72,8 @@ endfunction()
 
 # Take the version declared in the package, and increase the right number if we
 # are actually installing a developement version from after the latest git tag
-function(create_development_version _version_ _output_)
-    git_version_info(_n_commits_ _git_hash_)
+function(create_development_version _version_ _output_ _tag_prefix_)
+    git_version_info(_tag_prefix_ _n_commits_ _git_hash_)
 
     parse_version(${_version_} _major_ _minor_ _patch_ _rc_)
     if(${_n_commits_} STREQUAL "0")

--- a/featomic-torch/tests/cmake-project/CMakeLists.txt
+++ b/featomic-torch/tests/cmake-project/CMakeLists.txt
@@ -7,7 +7,7 @@ project(featomic-torch-test-cmake-project CXX)
 # featomic version for dev builds
 include(../../cmake/dev-versions.cmake)
 set(REQUIRED_FEATOMIC_TORCH_VERSION "0.0.0")
-create_development_version("${REQUIRED_FEATOMIC_TORCH_VERSION}" FEATOMIC_TORCH_FULL_VERSION)
+create_development_version("${REQUIRED_FEATOMIC_TORCH_VERSION}" FEATOMIC_TORCH_FULL_VERSION "featomic-torch-v")
 string(REGEX REPLACE "([0-9]*)\\.([0-9]*).*" "\\1.\\2" REQUIRED_FEATOMIC_TORCH_VERSION ${FEATOMIC_TORCH_FULL_VERSION})
 find_package(featomic_torch ${REQUIRED_FEATOMIC_TORCH_VERSION} REQUIRED)
 

--- a/featomic/CMakeLists.txt
+++ b/featomic/CMakeLists.txt
@@ -34,7 +34,7 @@ foreach(line ${CARGO_TOML_CONTENT})
 endforeach()
 
 include(cmake/dev-versions.cmake)
-create_development_version("${FEATOMIC_VERSION}" FEATOMIC_FULL_VERSION)
+create_development_version("${FEATOMIC_VERSION}" FEATOMIC_FULL_VERSION "featomic-v")
 message(STATUS "Building featomic v${FEATOMIC_FULL_VERSION}")
 
 # strip any -dev/-rc suffix on the version since project(VERSION) does not support it

--- a/featomic/cmake/dev-versions.cmake
+++ b/featomic/cmake/dev-versions.cmake
@@ -23,7 +23,7 @@ endif()
 
 # Get the time of the last modification since the last tag/release, and a hash
 # of the latest commit/full state of a dirty repository
-function(git_version_info _output_n_commits_ _output_git_hash_)
+function(git_version_info _tag_prefix_ _output_n_commits_ _output_git_hash_)
     set(_script_ "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/../../scripts/git-version-info.py")
 
     if (EXISTS "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/git_version_info")
@@ -37,7 +37,7 @@ function(git_version_info _output_n_commits_ _output_git_hash_)
         # When building from a checkout, we'll need to run the script
         find_package(Python COMPONENTS Interpreter REQUIRED)
         execute_process(
-            COMMAND "${Python_EXECUTABLE}" "${_script_}" "featomic-v"
+            COMMAND "${Python_EXECUTABLE}" "${_script_}" "${_tag_prefix_}"
             RESULT_VARIABLE _status_
             OUTPUT_VARIABLE _stdout_
             ERROR_VARIABLE _stderr_
@@ -72,8 +72,8 @@ endfunction()
 
 # Take the version declared in the package, and increase the right number if we
 # are actually installing a developement version from after the latest git tag
-function(create_development_version _version_ _output_)
-    git_version_info(_n_commits_ _git_hash_)
+function(create_development_version _version_ _output_ _tag_prefix_)
+    git_version_info(_tag_prefix_ _n_commits_ _git_hash_)
 
     parse_version(${_version_} _major_ _minor_ _patch_ _rc_)
     if(${_n_commits_} STREQUAL "0")

--- a/featomic/tests/cmake-project/CMakeLists.txt
+++ b/featomic/tests/cmake-project/CMakeLists.txt
@@ -6,7 +6,7 @@ project(featomic-test-cmake-project C CXX)
 # featomic version for dev builds
 include(../../cmake/dev-versions.cmake)
 set(REQUIRED_FEATOMIC_VERSION "0.0.0")
-create_development_version("${REQUIRED_FEATOMIC_VERSION}" FEATOMIC_FULL_VERSION)
+create_development_version("${REQUIRED_FEATOMIC_VERSION}" FEATOMIC_FULL_VERSION "featomic-v")
 string(REGEX REPLACE "([0-9]*)\\.([0-9]*).*" "\\1.\\2" REQUIRED_FEATOMIC_VERSION ${FEATOMIC_FULL_VERSION})
 find_package(featomic ${REQUIRED_FEATOMIC_VERSION} REQUIRED)
 


### PR DESCRIPTION
When building featomic-torch, we need to create development version differently for featomic and featomic-torch.

Follow up to #348 

<!-- readthedocs-preview featomic start -->
----
📚 Documentation preview 📚: https://featomic--354.org.readthedocs.build/en/354/

<!-- readthedocs-preview featomic end -->

<!-- download-section Build Python wheels start -->
⚙️ [Download Python wheels for this pull-request (you can install these with pip)](https://nightly.link/metatensor/featomic/actions/artifacts/2274689056.zip)

<!-- download-section Build Python wheels end -->