### PR TITLE
Fix YAML syntax for rust tests

### DIFF
--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -88,7 +88,7 @@ jobs:
 
       - name: setup Python
         uses: actions/setup-python@v5
-        if: !matrix.container
+        if: "!matrix.container"
         with:
           python-version: "3.12"
 


### PR DESCRIPTION
`!FOOBAR` is special YAML syntax, so we need to put this inside a string. I'm not sure why CI did not catch this.

<!-- readthedocs-preview featomic start -->
----
📚 Documentation preview 📚: https://featomic--369.org.readthedocs.build/en/369/

<!-- readthedocs-preview featomic end -->