### PR TITLE
Release featomic-torch v0.6.1

### DIFF
--- a/featomic-torch/CHANGELOG.md
+++ b/featomic-torch/CHANGELOG.md
@@ -17,6 +17,13 @@ a changelog](https://keepachangelog.com/en/1.1.0/) format. This project follows
 ### Removed
 -->
 
+## [Version 0.6.1](https://github.com/metatensor/featomic/releases/tag/featomic-torch-v0.6.1) - 2025-02-18\
+
+## Added
+
+- Add Support for Python 3.13 and PyTorch 2.6
+
+
 ## [Version 0.6.0](https://github.com/metatensor/featomic/releases/tag/featomic-torch-v0.6.0) - 2025-01-07
 
 ### Added

--- a/featomic-torch/tests/cmake-project/CMakeLists.txt
+++ b/featomic-torch/tests/cmake-project/CMakeLists.txt
@@ -6,7 +6,7 @@ project(featomic-torch-test-cmake-project CXX)
 # We need to update the REQUIRED_FEATOMIC_VERSION in the same way we update the
 # featomic version for dev builds
 include(../../cmake/dev-versions.cmake)
-set(REQUIRED_FEATOMIC_TORCH_VERSION "0.6.0")
+set(REQUIRED_FEATOMIC_TORCH_VERSION "0.6.1")
 create_development_version("${REQUIRED_FEATOMIC_TORCH_VERSION}" FEATOMIC_TORCH_FULL_VERSION "featomic-torch-v")
 string(REGEX REPLACE "([0-9]*)\\.([0-9]*).*" "\\1.\\2" REQUIRED_FEATOMIC_TORCH_VERSION ${FEATOMIC_TORCH_FULL_VERSION})
 find_package(featomic_torch ${REQUIRED_FEATOMIC_TORCH_VERSION} REQUIRED)


### PR DESCRIPTION
Patch release that includes new builds for Python 3.13 and Pytorch 2.6.

# TODO

- [x] Merge #384 

<!-- download-section Documentation docs start -->
[📚 Download documentation for this pull-request](https://nightly.link/metatensor/featomic/actions/artifacts/2611539400.zip)

<!-- download-section Documentation docs end -->

<!-- download-section Build Python wheels wheels start -->
[⚙️ [Download Python wheels for this pull-request (you can install these with pip)](https://nightly.link/metatensor/featomic/actions/artifacts/2611643510.zip)

<!-- download-section Build Python wheels wheels end -->